### PR TITLE
fix(docker): Disable CSP upgrade insecure requests setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ ci(github): Add automatic release workflow
 docs(readme): Add release instructions
 refactor(server): Move video upload to separate module
 build(docker): Add docker-compose file
+fix(client): Fix bug when uploading videos
 ```
 
 The exact format required is based on the Angular commit message format. See 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,11 @@
+services:
+  match_uploader_dev:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    ports:
+      - 8080:8080
+    volumes:
+      - ./server/settings:/home/node/app/server/settings
+      - ./server/env:/home/node/app/server/env
+      - ./server/videos:/home/node/app/server/videos

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,4 +5,5 @@ services:
       - 8080:8080
     volumes:
      - ./server/settings:/home/node/app/server/settings
+     - ./server/env:/home/node/app/server/env
      - ./server/videos:/home/node/app/server/videos

--- a/server/package.json
+++ b/server/package.json
@@ -38,7 +38,7 @@
     "fast-glob": "^3.3.1",
     "fs-extra": "^11.1.0",
     "google-auth-library": "^8.7.0",
-    "helmet": "^6.0.1",
+    "helmet": "^7.0.0",
     "inserturlparams": "^1.0.1",
     "jet-logger": "^1.3.1",
     "module-alias": "^2.2.2",

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -30,7 +30,13 @@ if (EnvVars.NodeEnv === NodeEnvs.Dev) {
 
 // Security
 if (EnvVars.NodeEnv === NodeEnvs.Production) {
-  app.use(helmet());
+  app.use(helmet({
+    contentSecurityPolicy: {
+      directives: {
+        upgradeInsecureRequests: null,
+      },
+    },
+  }));
 }
 
 // Add APIs, must be after middleware

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -1725,10 +1725,10 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-helmet@^6.0.1:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/helmet/-/helmet-6.2.0.tgz#c29d62014be4c70b8ef092c9c5e54c8c26b8e16e"
-  integrity sha512-DWlwuXLLqbrIOltR6tFQXShj/+7Cyp0gLi6uAb8qMdFh/YBBFbKSgQ6nbXmScYd8emMctuthmgIa7tUfo9Rtyg==
+helmet@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/helmet/-/helmet-7.0.0.tgz#ac3011ba82fa2467f58075afa58a49427ba6212d"
+  integrity sha512-MsIgYmdBh460ZZ8cJC81q4XJknjG567wzEmv46WOBblDb6TUd3z8/GhgmsM9pn8g2B80tAJ4m5/d3Bi1KrSUBQ==
 
 hexoid@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
When running with the Node environment set to production, the server enables Helmet, which adds several headers that are important for web app security.

With the expectation that the app currently doesn't support HTTPS, this PR intentionally disables the Content Security Policy `upgrade-insecure-requests` header such that the app can be loaded over HTTP even off localhost.
* This change doesn't preclude running the app _with_ HTTPS

It's worth noting that the app already has no access control and thus should only be hosted either locally or on private/trusted local networks anyways. The server does not expose plaintext secrets, but the client does send secret values in plaintext to the server to save them.

---
Other minor fixes in this PR:
- Add the server env files directory as a volume in docker-compose.yml