### PR TITLE
fix(server): Fix bug when matching double elim playoff matches 2-13

### DIFF
--- a/server/spec/tests/repos/JsonStorageRepo.spec.ts
+++ b/server/spec/tests/repos/JsonStorageRepo.spec.ts
@@ -1,19 +1,6 @@
-/* globals describe expect expectAsync it */
 import mockFs from "mock-fs";
-import { type ISettings } from "@src/models/Settings";
 import { readSettingsJson } from "@src/repos/JsonStorageRepo";
-
-const sampleSettings: ISettings = {
-  eventName: "Example Event",
-  eventTbaCode: "2023gacmp",
-  videoSearchDirectory: "./videos",
-  googleAuthStatus: "",
-  googleClientId: "",
-  playoffsType: "Double elimination playoff",
-  sandboxModeEnabled: false,
-  youTubeVideoPrivacy: "private",
-  linkVideosOnTheBlueAlliance: false,
-};
+import { sampleSettings } from "../util";
 
 describe("readSettingsJson", () => {
   it("should throw if settings file doesn't exist", async () => {

--- a/server/spec/tests/repos/MatchKey.spec.ts
+++ b/server/spec/tests/repos/MatchKey.spec.ts
@@ -1,0 +1,51 @@
+import { CompLevel } from "@src/models/CompLevel";
+import MatchKey from "@src/models/MatchKey";
+import { PlayoffsType } from "@src/models/PlayoffsType";
+
+describe("MatchKey", () => {
+    it("should parse a valid qualification match key", () => {
+        const matchkey = MatchKey.fromString("2023gadal_qm16", PlayoffsType.DoubleElimination);
+        expect(matchkey.compLevel).toEqual(CompLevel.Qualification);
+        expect(matchkey.eventCode).toEqual("gadal");
+        expect(matchkey.matchNumber).toEqual(16);
+        expect(matchkey.setNumber).toBeNull();
+        expect(matchkey.year).toEqual(2023);
+    });
+
+    it("should parse valid double elimination playoff match keys", () => {
+        const sf1m1 = MatchKey.fromString("2023gadal_sf1m1", PlayoffsType.DoubleElimination);
+        expect(sf1m1.compLevel).toEqual(CompLevel.Semifinal);
+        expect(sf1m1.eventCode).toEqual("gadal");
+        expect(sf1m1.matchNumber).toEqual(1);
+        expect(sf1m1.setNumber).toEqual(1);
+        expect(sf1m1.year).toEqual(2023);
+
+        const sf2m1 = MatchKey.fromString("2023gadal_sf2m1", PlayoffsType.DoubleElimination);
+        expect(sf2m1.compLevel).toEqual(CompLevel.Semifinal);
+        expect(sf2m1.eventCode).toEqual("gadal");
+        expect(sf2m1.matchNumber).toEqual(1);
+        expect(sf2m1.setNumber).toEqual(2);
+        expect(sf2m1.year).toEqual(2023);
+
+        const f1m1 = MatchKey.fromString("2023gadal_f1m1", PlayoffsType.DoubleElimination);
+        expect(f1m1.compLevel).toEqual(CompLevel.Final);
+        expect(f1m1.eventCode).toEqual("gadal");
+        expect(f1m1.matchNumber).toEqual(1);
+        expect(f1m1.setNumber).toEqual(1);
+        expect(f1m1.year).toEqual(2023);
+
+        const f1m2 = MatchKey.fromString("2023gadal_f1m2", PlayoffsType.DoubleElimination);
+        expect(f1m2.compLevel).toEqual(CompLevel.Final);
+        expect(f1m2.eventCode).toEqual("gadal");
+        expect(f1m2.matchNumber).toEqual(2);
+        expect(f1m2.setNumber).toEqual(1);
+        expect(f1m2.year).toEqual(2023);
+
+        const f1m3 = MatchKey.fromString("2023gadal_f1m3", PlayoffsType.DoubleElimination);
+        expect(f1m3.compLevel).toEqual(CompLevel.Final);
+        expect(f1m3.eventCode).toEqual("gadal");
+        expect(f1m3.matchNumber).toEqual(3);
+        expect(f1m3.setNumber).toEqual(1);
+        expect(f1m3.year).toEqual(2023);
+    });
+});

--- a/server/spec/tests/repos/MatchesServices.spec.ts
+++ b/server/spec/tests/repos/MatchesServices.spec.ts
@@ -1,0 +1,30 @@
+// Test getLocalVideoFilesForMatch function, using mockFs
+import { getLocalVideoFilesForMatch } from "@src/services/MatchesService";
+import MatchKey from "@src/models/MatchKey";
+import { PlayoffsType } from "@src/models/PlayoffsType";
+import mockFs from "mock-fs";
+import { sampleSettings } from "../util";
+
+const sampleVideos = {
+    "Qualification 1.mp4": "",
+    "Qualification 2.mp4": "",
+    "Qualification 10.mp4": "",
+    "Playoff 1.mp4": "",
+    "Playoff 2.mp4": "",
+    "Playoff 10.mp4": "",
+};
+
+describe("MatchesService", () => {
+    it("should return an empty array if no files are found", async () => {
+        mockFs({
+            videos: sampleVideos,
+            "settings/settings.example.json": JSON.stringify(sampleSettings),
+        });
+
+        const files = await getLocalVideoFilesForMatch(
+            MatchKey.fromString("2023gadal_qm16", PlayoffsType.DoubleElimination),
+        );
+        expect(files).toEqual([]);
+        mockFs.restore();
+    });
+});

--- a/server/spec/tests/util.ts
+++ b/server/spec/tests/util.ts
@@ -1,0 +1,14 @@
+import { type ISettings } from "@src/models/Settings";
+
+export const sampleSettings: ISettings = {
+    eventName: "Example Event",
+    eventTbaCode: "2023gacmp",
+    videoSearchDirectory: "./videos",
+    googleAuthStatus: "",
+    googleClientId: "",
+    playoffsType: "Double elimination playoff",
+    sandboxModeEnabled: false,
+    youTubeVideoPrivacy: "private",
+    linkVideosOnTheBlueAlliance: false,
+    useFrcEventsApi: false,
+};

--- a/server/src/services/MatchesService.ts
+++ b/server/src/services/MatchesService.ts
@@ -11,22 +11,23 @@ import { type TbaFrcTeam } from "@src/models/theBlueAlliance/tbaFrcTeam";
 import { FrcEventsRepo } from "@src/repos/FrcEventsRepo";
 import { PlayoffsType } from "@src/models/PlayoffsType";
 import { getFrcApiMatchNumber } from "@src/models/frcEvents/frcScoredMatch";
-import { toFrcEventsUrlTournamentLevel } from "@src/models/CompLevel";
+import { CompLevel, toFrcEventsUrlTournamentLevel } from "@src/models/CompLevel";
+import logger from "jet-logger";
 
 export async function getLocalVideoFilesForMatch(matchKey: MatchKey): Promise<MatchVideoInfo[]> {
-    const settings = await getSettings();
+    const { eventName, videoSearchDirectory } = await getSettings();
     const match = new Match(matchKey);
     const videoFileMatchingName = capitalizeFirstLetter(match.videoFileMatchingName);
     const matchTitleName = capitalizeFirstLetter(match.verboseMatchName);
-    const eventName = settings.eventName;
 
-    const files = await getFilesMatchingPattern(settings.videoSearchDirectory, `${videoFileMatchingName}*`);
+    const files = await getFilesMatchingPattern(videoSearchDirectory, `${videoFileMatchingName}*`);
     const parseVideoLabelsRegex = /^[A-Za-z]+ (\d{1,3})\s?([A-Za-z\s]*)\..*$/;
 
     return files.filter(file => {
         const proposedVideoLabel = parseVideoLabelsRegex.exec(file);
 
         // Filter out this file if the pattern is incorrect
+        logger.info(`proposedVideoLabel: ${proposedVideoLabel}`);
         if (!proposedVideoLabel || proposedVideoLabel.length < 3) {
             return false;
         }
@@ -34,12 +35,23 @@ export async function getLocalVideoFilesForMatch(matchKey: MatchKey): Promise<Ma
         // Pulls the actual match number out of the file name using the 2nd capture group in parseVideoLabelsRegex
         const fileMatchNumber = proposedVideoLabel[1];
 
-        // Filter out this file if the match number in the file name doesn't match the match we want to get videos for
-        if (!fileMatchNumber || Number.parseInt(fileMatchNumber, 10) !== match.key.matchNumber) {
+        logger.info(`fileMatchNumber: ${fileMatchNumber}`);
+        logger.info(`match.key.matchNumber: ${match.key.matchNumber}`);
+        logger.info(`match.key.setNumber: ${match.key.setNumber}`);
+
+        if (!fileMatchNumber) {
             return false;
         }
 
-        return true;
+        // In double eliminations, playoff matches (before finals) have their sequence number in the set number, not
+        // the match number
+        if (match.key.playoffsType === PlayoffsType.DoubleElimination && match.key.compLevel === CompLevel.Semifinal) {
+            return Number.parseInt(fileMatchNumber, 10) === match.key.setNumber;
+        }
+
+        // Otherwise, check that when parsed as a number, the match number in the file name matches the match for which
+        // we are finding videos
+        return Number.parseInt(fileMatchNumber, 10) === match.key.matchNumber;
     }).map((file) => {
         const proposedVideoLabel = parseVideoLabelsRegex.exec(file);
         let videoLabel: string | null = null;

--- a/server/src/services/MatchesService.ts
+++ b/server/src/services/MatchesService.ts
@@ -12,7 +12,6 @@ import { FrcEventsRepo } from "@src/repos/FrcEventsRepo";
 import { PlayoffsType } from "@src/models/PlayoffsType";
 import { getFrcApiMatchNumber } from "@src/models/frcEvents/frcScoredMatch";
 import { CompLevel, toFrcEventsUrlTournamentLevel } from "@src/models/CompLevel";
-import logger from "jet-logger";
 
 export async function getLocalVideoFilesForMatch(matchKey: MatchKey): Promise<MatchVideoInfo[]> {
     const { eventName, videoSearchDirectory } = await getSettings();

--- a/server/src/services/MatchesService.ts
+++ b/server/src/services/MatchesService.ts
@@ -27,17 +27,12 @@ export async function getLocalVideoFilesForMatch(matchKey: MatchKey): Promise<Ma
         const proposedVideoLabel = parseVideoLabelsRegex.exec(file);
 
         // Filter out this file if the pattern is incorrect
-        logger.info(`proposedVideoLabel: ${proposedVideoLabel}`);
         if (!proposedVideoLabel || proposedVideoLabel.length < 3) {
             return false;
         }
 
         // Pulls the actual match number out of the file name using the 2nd capture group in parseVideoLabelsRegex
         const fileMatchNumber = proposedVideoLabel[1];
-
-        logger.info(`fileMatchNumber: ${fileMatchNumber}`);
-        logger.info(`match.key.matchNumber: ${match.key.matchNumber}`);
-        logger.info(`match.key.setNumber: ${match.key.setNumber}`);
 
         if (!fileMatchNumber) {
             return false;


### PR DESCRIPTION
In double eliminations, The Blue Alliance match keys increment the set number for playoff matches 1-13 (`sf1m1`, `sf2m1`, etc.). We were still comparing match numbers even for these matches, which was preventing finding match video files for anything besides Playoff Match 1.

I wanted to write a unit test to catch this specific case, but testing the function turned out to not be trivial, so while I did add some more tests, I didn't add a test that would catch this specific issue.

Fixes #68