### PR TITLE
fix(ci): Use Node 20 for release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.x
           cache: 'yarn'
           cache-dependency-path: '**/yarn.lock'
       - name: yarn install


### PR DESCRIPTION
Semantic Release now requires Node 20. This should have no affect on our Docker build process though.

Failed release job: https://github.com/gafirst/match-uploader/actions/runs/7689310267/job/20951572761