### PR TITLE
feat: Allow cancelling jobs from client

### DIFF
--- a/client/src/components/jobs/JobsList.vue
+++ b/client/src/components/jobs/JobsList.vue
@@ -1,4 +1,10 @@
 <template>
+  <VAlert v-if="workerStore.jobCancellationError"
+          class="mt-2"
+          color="error"
+  >
+    {{ workerStore.jobCancellationError }}
+  </VAlert>
   <VList>
     <div v-for="job in jobsList" :key="job.jobId">
       <JobListItem :job="job" />
@@ -8,6 +14,9 @@
 <script lang="ts" setup>
 import {WorkerJob} from "@/types/WorkerJob";
 import JobListItem from "@/components/jobs/JobListItem.vue";
+import { useWorkerStore } from "@/stores/worker";
+
+const workerStore = useWorkerStore();
 
 const props = defineProps<{
   jobsList: WorkerJob[]

--- a/client/src/stores/match.ts
+++ b/client/src/stores/match.ts
@@ -88,7 +88,7 @@ export const useMatchStore = defineStore("match", () => {
   const allMatchVideosUploaded = computed(() => {
     return matchVideos.value.length > 0 &&
       matchVideos.value.every(
-        video => workerStore.jobHasStatus(video.workerJobId,[WorkerJobStatus.COMPLETED, WorkerJobStatus.FAILED]),
+        video => workerStore.jobHasStatus(video.workerJobId,[WorkerJobStatus.COMPLETED]),
       );
   });
 

--- a/client/src/stores/worker.ts
+++ b/client/src/stores/worker.ts
@@ -210,10 +210,32 @@ export const useWorkerStore = defineStore("worker", () => {
     });
   }
 
+  const jobCancellationError = ref("");
+  async function cancelJob(jobId: string) {
+    jobCancellationError.value = "";
+
+    const result = await fetch("/api/v1/worker/jobs/cancel", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        jobId,
+        reason: "Cancelled by user",
+      }),
+    });
+
+    if (!result.ok) {
+      jobCancellationError.value = `API error (${result.status} ${result.statusText}): Error deleting job #${jobId}`;
+    }
+  }
+
   return {
     bindEvents,
+    cancelJob,
     events,
     isConnected,
+    jobCancellationError,
     jobCountsByStatus,
     jobHasStatus,
     jobs,

--- a/server/src/tasks/types/events.ts
+++ b/server/src/tasks/types/events.ts
@@ -11,9 +11,8 @@ export interface CommonEvents {
         payload: unknown;
     };
     [WORKER_JOB_COMPLETE]: {
-        workerId: string,
+        workerId: string | null,
         jobId: string,
-        jobName: string,
         attempts: number,
         maxAttempts: number,
         payload: unknown,
@@ -44,9 +43,7 @@ export function isWorkerJobStartEvent(x: unknown): x is CommonEvents[typeof WORK
 export function isWorkerJobCompleteEvent(x: unknown): x is CommonEvents[typeof WORKER_JOB_COMPLETE] {
     return typeof x === "object" &&
         x !== null &&
-        "workerId" in x &&
         "jobId" in x &&
-        "jobName" in x &&
         "attempts" in x &&
         "maxAttempts" in x &&
         "payload" in x &&


### PR DESCRIPTION
Adds a simple feature to cancel pending jobs.

Specifics:
- Jobs can only be cancelled from `PENDING` or `FAILED_RETRYABLE` statuses. This means you can't stop an in-progress job.
- To cancel a job, users click the trash can icon, which causes the button to change to an intermediate confirmation step that shows `Delete?`. A second click cancels the job. The intermediate step will revert after 5 seconds if the button isn't clicked.

- [x] Quick test of Docker Compose setup is clear

Closes #82

![cancel-demo-final](https://github.com/gafirst/match-uploader/assets/5790137/a9f84b39-e361-4007-a8ad-921ae406c996)