### PR TITLE
feat: Implement full Next Match button functionality

### DIFF
--- a/client/src/components/matches/MatchSelector.vue
+++ b/client/src/components/matches/MatchSelector.vue
@@ -52,7 +52,7 @@
       >
         View on TBA
       </VBtn>
-      <VBtn v-if="matchStore.selectedMatchKey"
+      <VBtn v-if="shouldShowNextMatchBtn"
             :variant="!matchStore.allMatchVideosQueued ? 'outlined' : undefined"
             :disabled="matchStore.uploadInProgress"
             :loading="matchStore.nextMatchLoading"
@@ -62,6 +62,20 @@
       >
         Next match
       </VBtn>
+
+      <VAlert v-else
+              color="warning"
+              variant="tonal"
+              class="mt-2"
+      >
+        <p class="mb-2">
+          The Next Match button is unavailable because the playoffs type is not set to double elimination.
+        </p>
+        <p>
+          If this is unintentional, update the playoffs type in
+          <RouterLink to="/settings">Settings</RouterLink>.
+        </p>
+      </VAlert>
     </VCol>
   </VRow>
 </template>
@@ -69,10 +83,11 @@
 <script lang="ts" setup>
 import {useMatchStore} from "@/stores/match";
 import {useMatchListStore} from "@/stores/matchList";
-import {onMounted} from "vue";
+import { computed, onMounted } from "vue";
 import FrcEventsWarning from "@/components/alerts/FrcEventsWarning.vue";
 import {useSettingsStore} from "@/stores/settings";
 import MatchDataAttribution from "@/components/matches/MatchDataAttribution.vue";
+import { PLAYOFF_DOUBLE_ELIM } from "@/types/MatchType";
 
 const matchStore = useMatchStore();
 const matchListStore = useMatchListStore();
@@ -81,6 +96,11 @@ const settingsStore = useSettingsStore();
 onMounted(() => {
   matchListStore.getMatchList();
 });
+
+const shouldShowNextMatchBtn = computed(
+  () => matchStore.selectedMatchKey &&
+    (settingsStore.isFirstLoad || settingsStore.settings?.playoffsType === PLAYOFF_DOUBLE_ELIM),
+);
 
 async function matchSelected(matchKey: string) {
   await matchStore.selectMatch(matchKey);

--- a/client/src/components/matches/MatchSelector.vue
+++ b/client/src/components/matches/MatchSelector.vue
@@ -1,39 +1,44 @@
 <template>
-  <VAlert v-if="!!matchListStore.error"
-          color="error"
-          class="mb-4"
-  >
-    {{ matchListStore.error }}
-  </VAlert>
-
   <VRow class="mb-1">
     <VCol>
-      <MatchDataAttribution />
-    </VCol>
-  </VRow>
+      <MatchDataAttribution class="mb-4" />
+      <VAlert v-if="!!matchListStore.error"
+              color="error"
+              variant="tonal"
+              class="mb-2"
+      >
+        {{ matchListStore.error }}
+      </VAlert>
 
-  <!--
-  Note: this component may be laggy when running in development, but in production builds the performance
-  should become significantly better.
-  -->
-  <v-autocomplete v-model="matchStore.selectedMatchKey"
-                  :items="matchListStore.matches"
-                  :loading="matchListStore.loading"
-                  rounded
-                  auto-select-first
-                  placeholder="Select a match..."
-                  variant="outlined"
-                  label="Match"
-                  item-title="verboseName"
-                  item-value="key"
-                  :disabled="matchStore.uploadInProgress || !!matchListStore.error"
-                  @update:model-value="matchSelected"
-  />
-  <VRow>
-    <VCol>
+      <VAlert v-if="!!matchStore.nextMatchError"
+              color="warning"
+              variant="tonal"
+              class="mb-2"
+      >
+        {{ matchStore.nextMatchError }}
+      </VAlert>
+      <!--
+      Note: this component may be laggy when running in development, but in production builds the performance
+      should become significantly better.
+      -->
+      <v-autocomplete v-model="matchStore.selectedMatchKey"
+                      class="mt-6"
+                      :items="matchListStore.matches"
+                      :loading="matchListStore.loading"
+                      rounded
+                      auto-select-first
+                      placeholder="Select a match..."
+                      variant="outlined"
+                      label="Match"
+                      item-title="verboseName"
+                      item-value="key"
+                      :disabled="matchStore.uploadInProgress || !!matchListStore.error"
+                      @update:model-value="matchSelected"
+      />
       <VBtn :disabled="matchStore.uploadInProgress"
             prepend-icon="mdi-refresh"
             variant="outlined"
+            class="mr-2 mb-2"
             @click="matchListStore.getMatchList(true)"
       >
         Refresh
@@ -41,35 +46,22 @@
       <VBtn v-if="!settingsStore.settings?.useFrcEventsApi && matchStore.selectedMatchKey"
             prepend-icon="mdi-open-in-new"
             variant="outlined"
-            class="ml-2"
+            class="mr-2 mb-2"
             :href="`https://thebluealliance.com/match/${matchStore.selectedMatchKey}`"
             target="_blank"
       >
         View on TBA
       </VBtn>
-    </VCol>
-  </VRow>
-  <VRow class="mt-0">
-    <VCol>
       <VBtn v-if="matchStore.selectedMatchKey"
             :variant="!matchStore.allMatchVideosQueued ? 'outlined' : undefined"
             :disabled="matchStore.uploadInProgress"
+            :loading="matchStore.nextMatchLoading"
+            prepend-icon="mdi-skip-next"
+            class="mb-2"
             @click="matchStore.advanceMatch"
       >
-        Next match <VChip density="comfortable"
-                          variant="tonal"
-                          class="ml-2"
-        >
-          Beta
-        </VChip>
+        Next match
       </VBtn>
-    </VCol>
-  </VRow>
-  <VRow>
-    <VCol>
-      <VAlert v-if="matchStore.selectedMatchKey" class="mb-2">
-        Next Match only works for qualification and playoff finals matches.
-      </VAlert>
     </VCol>
   </VRow>
 </template>
@@ -91,7 +83,6 @@ onMounted(() => {
 });
 
 async function matchSelected(matchKey: string) {
-  console.log(matchKey);
   await matchStore.selectMatch(matchKey);
 }
 </script>

--- a/client/src/stores/matchList.ts
+++ b/client/src/stores/matchList.ts
@@ -19,7 +19,7 @@ export const useMatchListStore = defineStore("matchList", () => {
 
     async function getMatchList(forceRefresh = false): Promise<void> {
         if (matches.value.length > 0 && !forceRefresh) {
-            console.log("cached");
+            console.log("getMatchList: Returning cached match list");
             return;
         }
 
@@ -44,11 +44,16 @@ export const useMatchListStore = defineStore("matchList", () => {
         loading.value = false;
     }
 
+    function matchListContains(matchKey: string): boolean {
+      return matches.value.some((match) => match.key === matchKey);
+    }
+
     return {
         error,
         loading,
         matches,
         getMatchList,
+        matchListContains,
     };
 });
 

--- a/client/src/types/PossibleNextMatches.ts
+++ b/client/src/types/PossibleNextMatches.ts
@@ -1,0 +1,5 @@
+export interface PossibleNextMatches {
+  ok: boolean;
+  sameLevel: string;
+  nextLevel: string;
+}

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -11,9 +11,7 @@
       <h2 class="mb-2">Match info</h2>
       <MatchSelector />
 
-      <h2
-        class="mt-2 mb-2"
-      >
+      <h2 class="mb-2">
         Video metadata
       </h2>
       <MatchMetadata />

--- a/server/src/routes/constants/Paths.ts
+++ b/server/src/routes/constants/Paths.ts
@@ -20,6 +20,7 @@ const Paths = {
     Get: "/:matchKey",
     RecommendVideoFiles: "/:matchKey/videos/recommend",
     GenerateDescription: "/:matchKey/description",
+    PossibleNextMatches: "/:matchKey/nextMatch",
   },
   YouTube: {
     Base: "/youtube",


### PR DESCRIPTION
Adds full functionality for the Next Match button. Since the match list changes during the event and there's no clear "correct" ordering, we instead rely on parsing match keys to guess the next match and accept the guess if it's in the match list, refreshing the match list once if necessary.

![](https://github.com/gafirst/match-uploader/assets/5790137/dfde6496-6750-4ee1-98e2-e9cd13fce06b)

The full algorithm is:
1. Client sends a request to the server to return possible next matches (this is because the server has better abstractions around parsing match keys that aren't worth replicating to the frontend)
2. Server responds with up to 2 matches:
   1. The next match in the same tournament phase (ex: qual 1 -> qual 2)
   2. The first match in the next tournament phase (ex: qual 34 -> playoff 1)
3. Client checks its current match list to see if option 1 is in the match list, or if not, if option 2 is in the match list
4. If neither match suggestion exists, refresh the match list and try again
5. If neither match suggestion exists still, show an error

Due to low usage of best of 3 playoffs nowadays, this feature only supports double eliminations. A warning appears if the Next Match button can't be used because of the current playoffs type.
![](https://github.com/gafirst/match-uploader/assets/5790137/a2fe6ede-f244-456f-9198-856e96b52fcb)

Closes #62