### PR TITLE
fix: Fix Next Match bug and refresh match list on settings changes

### DIFF
--- a/client/src/components/matches/MatchSelector.vue
+++ b/client/src/components/matches/MatchSelector.vue
@@ -63,7 +63,7 @@
         Next match
       </VBtn>
 
-      <VAlert v-else
+      <VAlert v-else-if="shouldShowNextMatchBtnUnavailableError"
               color="warning"
               variant="tonal"
               class="mt-2"
@@ -100,6 +100,12 @@ onMounted(() => {
 const shouldShowNextMatchBtn = computed(
   () => matchStore.selectedMatchKey &&
     (settingsStore.isFirstLoad || settingsStore.settings?.playoffsType === PLAYOFF_DOUBLE_ELIM),
+);
+
+const shouldShowNextMatchBtnUnavailableError = computed(
+  () => !settingsStore.isFirstLoad
+    && settingsStore.settings?.playoffsType !== PLAYOFF_DOUBLE_ELIM
+    && matchStore.selectedMatchKey,
 );
 
 async function matchSelected(matchKey: string) {

--- a/client/src/components/matches/MatchVideosUploader.vue
+++ b/client/src/components/matches/MatchVideosUploader.vue
@@ -66,7 +66,6 @@ import MatchVideoListItem from "@/components/matches/MatchVideoListItem.vue";
 import {useSettingsStore} from "@/stores/settings";
 import SandboxModeAlert from "@/components/alerts/SandboxModeAlert.vue";
 import PrivateUploads from "@/components/alerts/PrivateUploads.vue";
-import QueueAllVideosBtn from "@/components/matches/QueueAllVideosBtn.vue";
 import { computed } from "vue";
 import LoadingSpinner from "@/components/util/LoadingSpinner.vue";
 

--- a/client/src/views/Settings.vue
+++ b/client/src/views/Settings.vue
@@ -219,8 +219,8 @@
         <p class="mt-4">Retrieve match data from FRC Events</p>
         <AutosavingBtnSelectGroup :choices="['On', 'Off']"
                                   :default-value="settingsStore.settings?.useFrcEventsApi ? 'On' : 'Off'"
-                                  :loading="savingFrcEventsApiKey"
-                                  @on-choice-selected="saveFrcEventsApiKey"
+                                  :loading="savingFrcEventsEnabled"
+                                  @on-choice-selected="saveFrcEventsEnabled"
         />
 
         <VAlert v-if="!settingsStore.settings?.useFrcEventsApi"
@@ -325,6 +325,7 @@ import AutosavingBtnSelectGroup from "@/components/form/AutosavingBtnSelectGroup
 import {useSettingsStore} from "@/stores/settings";
 import YouTubePlaylistMapping from "@/components/youtube/YouTubePlaylistMapping.vue";
 import { useMatchStore } from "@/stores/match";
+import { useMatchListStore } from "@/stores/matchList";
 
 // const loading = ref(true);
 const loading = computed(() => {
@@ -336,6 +337,7 @@ const error = computed(() => {
   return settingsStore.error;
 });
 const matchStore = useMatchStore();
+const matchListStore = useMatchListStore();
 const settingsStore = useSettingsStore();
 // const settings = ref<ISettings | null>(null);
 // const youTubeAuthState = ref<IYouTubeAuthState | null>(null);
@@ -389,6 +391,7 @@ async function savePlayoffMatchType(value: string): Promise<void> {
   await submit("playoffsType", value, "setting");
   await refreshData(false);
   savingPlayoffMatchType.value = false;
+  await matchListStore.getMatchList(true);
 }
 
 // TODO: Move into its own component
@@ -432,13 +435,14 @@ const tbaReadApiKeyHelpText = computed((): string => {
 });
 
 // TODO: Move into its own component
-const savingFrcEventsApiKey = ref(false);
+const savingFrcEventsEnabled = ref(false);
 
-async function saveFrcEventsApiKey(value: string): Promise<void> {
-  savingFrcEventsApiKey.value = true;
+async function saveFrcEventsEnabled(value: string): Promise<void> {
+  savingFrcEventsEnabled.value = true;
   await submit("useFrcEventsApi", value === "On", "setting");
   await refreshData(false);
-  savingFrcEventsApiKey.value = false;
+  savingFrcEventsEnabled.value = false;
+  await matchListStore.getMatchList(true);
 }
 
 </script>


### PR DESCRIPTION
- Fixes bug where the Next Match button unavailable warning appeared incorrectly when the playoff type was double elims but no match was selected
- Automatically refresh the match list if either of the following settings are changed:
  - Playoff type
  - Use FRC Events API
- Remove unused `QueueAllVideosBtn` import that was causing errors in dev builds

Fixes #103 
Closes #86

- [x] Tested Docker setup locally