### PR TITLE
fix(client): Ensure stale data is discarded when event code changes

### DIFF
--- a/client/src/stores/match.ts
+++ b/client/src/stores/match.ts
@@ -29,6 +29,26 @@ export const useMatchStore = defineStore("match", () => {
     await getSuggestedDescription();
   }
 
+  /**
+   * Utility function to completely clear out the selected match and all related data that is derived from it.
+   */
+  function clearSelectedMatch() {
+    // Clear selected match key
+    selectedMatchKey.value = null;
+
+    // Clear data derived from selected match key:
+    matchVideos.value = [];
+    description.value = null;
+
+    // Clear loading/error states
+    nextMatchLoading.value = false;
+    nextMatchError.value = "";
+    matchVideosLoading.value = false;
+    matchVideoError.value = "";
+    descriptionLoading.value = false;
+    descriptionFetchError.value = "";
+  }
+
   async function getPossibleNextMatches(): Promise<PossibleNextMatches|undefined> {
     if (!selectedMatchKey.value) {
       return;
@@ -291,6 +311,7 @@ export const useMatchStore = defineStore("match", () => {
     allMatchVideosQueued,
     allMatchVideosUploaded,
     allowMatchUpload,
+    clearSelectedMatch,
     description,
     descriptionFetchError,
     descriptionLoading,

--- a/client/src/views/Settings.vue
+++ b/client/src/views/Settings.vue
@@ -11,7 +11,7 @@
       <div v-else>
         <h2>General</h2>
         <AutosavingTextInput :key="`eventName-${dataRefreshKey}`"
-                             :on-submit="submit"
+                             :on-submit="submitEventName"
                              :initial-value="settingsStore.settings?.eventName"
                              name="eventName"
                              label="Event name"
@@ -389,14 +389,20 @@ async function submit(settingName: string, value: string | boolean, settingType:
   return await settingsStore.saveSetting(settingName, value, settingType);
 }
 
+async function submitEventName(settingName: string, value: string | boolean, settingType: SettingType) {
+  // TODO(#114): Ideally we could alert other client instances that the event name has changed
+  const submitResult = await submit(settingName, value, settingType);
+  await matchStore.getMatchVideos();
+  return submitResult;
+}
+
 async function submitEventCode(settingName: string, value: string | boolean, settingType: SettingType) {
-  // TODO(#113): Ideally we could alert other client instances that the event code has changed
+  // TODO(#114): Ideally we could alert other client instances that the event code has changed
   const submitResult = await submit(settingName, value, settingType);
   await matchListStore.getMatchList(true);
   matchStore.clearSelectedMatch();
   return submitResult;
 }
-
 
 async function saveDescriptionTemplate(settingName: string, value: string, settingType: SettingType) {
   return await settingsStore.saveDescriptionTemplate(value);

--- a/client/src/views/Settings.vue
+++ b/client/src/views/Settings.vue
@@ -24,7 +24,7 @@
                 class="mb-4"
                 color="warning"
         >
-          Changing the event code will clear your currently selected match.
+          Changing the event code will clear the current selected match.
         </VAlert>
         <AutosavingTextInput :key="`eventTbaCode-${dataRefreshKey}`"
                              :on-submit="submitEventCode"

--- a/client/src/views/Settings.vue
+++ b/client/src/views/Settings.vue
@@ -19,8 +19,15 @@
                              setting-type="setting"
                              class="mt-4"
         />
+
+        <VAlert v-if="matchStore.selectedMatchKey"
+                class="mb-4"
+                color="warning"
+        >
+          Changing the event code will clear your currently selected match.
+        </VAlert>
         <AutosavingTextInput :key="`eventTbaCode-${dataRefreshKey}`"
-                             :on-submit="submit"
+                             :on-submit="submitEventCode"
                              :initial-value="settingsStore.settings?.eventTbaCode"
                              name="eventTbaCode"
                              label="Event TBA code"
@@ -381,6 +388,15 @@ onMounted(async () => {
 async function submit(settingName: string, value: string | boolean, settingType: SettingType) {
   return await settingsStore.saveSetting(settingName, value, settingType);
 }
+
+async function submitEventCode(settingName: string, value: string | boolean, settingType: SettingType) {
+  // TODO(#113): Ideally we could alert other client instances that the event code has changed
+  const submitResult = await submit(settingName, value, settingType);
+  await matchListStore.getMatchList(true);
+  matchStore.clearSelectedMatch();
+  return submitResult;
+}
+
 
 async function saveDescriptionTemplate(settingName: string, value: string, settingType: SettingType) {
   return await settingsStore.saveDescriptionTemplate(value);


### PR DESCRIPTION
If the user changes the event code, the following will now occur:
1. The client will refresh the match list
2. The currently selected match (which in reality is a match _key_ that is specific to an event) is cleared. This also clears the description text and found match video files, since these both depend on the selected match key.

This should mean that changing the event code will now "just work" without any need to refresh the page.

Other changes:
 - If the event name is changed, the match videos list will refresh to ensure the selected video titles are updated

TODO:
 - [x] Confirm that worker uploads are not affected by changing the event code (as in, any uploads scheduled prior to changing the event code should not be affected

Closes #113