### PR TITLE
feat(autoRename): Quality of life improvements for auto rename

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-auto_rename.yaml
+++ b/.github/ISSUE_TEMPLATE/1-auto_rename.yaml
@@ -9,6 +9,7 @@ body:
         - Strong association to the wrong match
         - Association status unexpectedly weak
         - Association was expected but not made
+        - Unexpected association (i.e., association shouldn't have been created)
         - Something else (describe in Additional Information)
     validations:
       required: true

--- a/client/src/components/autoRename/AutoRename.vue
+++ b/client/src/components/autoRename/AutoRename.vue
@@ -20,14 +20,24 @@
         >on GitHub</a>.
       </VAlert>
 
-      <VAlert density="compact" color="success" icon="mdi-check-circle"
-              variant="tonal" v-if="autoRenameStore.triggerNowSuccess"
-              class="mb-4">
+      <VAlert
+        v-if="autoRenameStore.triggerNowSuccess"
+        density="compact"
+        color="success"
+        icon="mdi-check-circle"
+        variant="tonal"
+        class="mb-4"
+      >
         Auto rename run scheduled and should begin shortly
       </VAlert>
-      <VAlert density="compact" color="error" icon="mdi-alert-circle"
-              variant="tonal" v-if="!!autoRenameStore.triggerNowError"
-              class="mb-4">
+      <VAlert
+        v-if="!!autoRenameStore.triggerNowError"
+        density="compact"
+        color="error"
+        icon="mdi-alert-circle"
+        variant="tonal"
+        class="mb-4"
+      >
         {{ autoRenameStore.triggerNowError }}
       </VAlert>
 
@@ -42,11 +52,16 @@
         @on-choice-selected="saveAutoRenameEnabled"
       />
 
-      <VBtn class="mb-2" variant="outlined" prepend-icon="mdi-refresh"
-            v-if="settingsStore.settings?.autoRenameEnabled"
-            @click="autoRenameStore.triggerNow"
-            :loading="autoRenameStore.triggerNowLoading"
-      >Trigger now</VBtn>
+      <VBtn
+        v-if="settingsStore.settings?.autoRenameEnabled"
+        class="mb-2"
+        variant="outlined"
+        prepend-icon="mdi-refresh"
+        :loading="autoRenameStore.triggerNowLoading"
+        @click="autoRenameStore.triggerNow"
+      >
+        Trigger now
+      </VBtn>
 
       <VAlert
         v-if="autoRenameStore.confirmWeakAssociationError"

--- a/client/src/components/autoRename/AutoRename.vue
+++ b/client/src/components/autoRename/AutoRename.vue
@@ -20,6 +20,17 @@
         >on GitHub</a>.
       </VAlert>
 
+      <VAlert density="compact" color="success" icon="mdi-check-circle"
+              variant="tonal" v-if="autoRenameStore.triggerNowSuccess"
+              class="mb-4">
+        Auto rename run scheduled and should begin shortly
+      </VAlert>
+      <VAlert density="compact" color="error" icon="mdi-alert-circle"
+              variant="tonal" v-if="!!autoRenameStore.triggerNowError"
+              class="mb-4">
+        {{ autoRenameStore.triggerNowError }}
+      </VAlert>
+
       <p class="mb-1">
         Enable auto rename
       </p>
@@ -30,6 +41,12 @@
         :loading="savingAutoRenameEnabled"
         @on-choice-selected="saveAutoRenameEnabled"
       />
+
+      <VBtn class="mb-2" variant="outlined" prepend-icon="mdi-refresh"
+            v-if="settingsStore.settings?.autoRenameEnabled"
+            @click="autoRenameStore.triggerNow"
+            :loading="autoRenameStore.triggerNowLoading"
+      >Trigger now</VBtn>
 
       <VAlert
         v-if="autoRenameStore.confirmWeakAssociationError"
@@ -113,6 +130,12 @@ async function saveAutoRenameEnabled(value: string): Promise<void> {
   await settingsStore.saveSetting("autoRenameEnabled", value.toLowerCase() === "on", "setting");
   await settingsStore.getSettings(false);
   savingAutoRenameEnabled.value = false;
+  if (value.toLowerCase() === "on") {
+    await autoRenameStore.triggerNow();
+  } else if (!autoRenameStore.triggerNowLoading) {
+    autoRenameStore.triggerNowSuccess = false;
+    autoRenameStore.triggerNowError = "";
+  }
 }
 
 </script>

--- a/client/src/components/autoRename/AutoRenameAssociations.vue
+++ b/client/src/components/autoRename/AutoRenameAssociations.vue
@@ -13,7 +13,7 @@
       { title: 'Actions', key: 'actions'}
     ]"
     multi-sort
-    :sort-by="[{ key: 'videoLabel', order: 'asc' }, { key: 'videoTimestamp', order: 'asc' }]"
+    :sort-by="[{key: 'status', order: 'desc' }, { key: 'videoLabel', order: 'asc' }, { key: 'videoTimestamp', order: 'asc' }]"
   >
     <!-- eslint-disable-next-line vue/valid-v-slot -->
     <template #item.status="{ item }">

--- a/client/src/components/autoRename/AutoRenameAssociations.vue
+++ b/client/src/components/autoRename/AutoRenameAssociations.vue
@@ -13,7 +13,11 @@
       { title: 'Actions', key: 'actions'}
     ]"
     multi-sort
-    :sort-by="[{key: 'status', order: 'desc' }, { key: 'videoLabel', order: 'asc' }, { key: 'videoTimestamp', order: 'asc' }]"
+    :sort-by="[
+      { key: 'status', order: 'desc' },
+      { key: 'videoLabel', order: 'asc' },
+      { key: 'videoTimestamp', order: 'asc' },
+    ]"
   >
     <!-- eslint-disable-next-line vue/valid-v-slot -->
     <template #item.status="{ item }">
@@ -112,6 +116,7 @@ import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
 import { useWorkerStore } from "@/stores/worker";
 import { WorkerJobStatus } from "@/types/WorkerJob";
+
 dayjs.extend(advancedFormat);
 dayjs.extend(duration);
 dayjs.extend(localizedFormat);

--- a/client/src/components/liveMode/LiveMode.vue
+++ b/client/src/components/liveMode/LiveMode.vue
@@ -127,10 +127,10 @@
             <template v-else>
               A video for the current match with the label above is still expected.
             </template>
-            If this is incorrect, go to <RouterLink to="/settings">
-              Settings
-            </RouterLink> and remove
-            any unnecessary playlist mappings.
+            If this is incorrect, go to
+            <!-- eslint-disable-next-line vue/singleline-html-element-content-newline -->
+            <RouterLink to="/settings">Settings</RouterLink>
+            and remove any unnecessary playlist mappings.
           </p>
         </VAlert>
 

--- a/client/src/components/liveMode/LiveMode.vue
+++ b/client/src/components/liveMode/LiveMode.vue
@@ -127,7 +127,9 @@
             <template v-else>
               A video for the current match with the label above is still expected.
             </template>
-            If this is incorrect, go to <RouterLink to="/settings">Settings</RouterLink> and remove
+            If this is incorrect, go to <RouterLink to="/settings">
+              Settings
+            </RouterLink> and remove
             any unnecessary playlist mappings.
           </p>
         </VAlert>

--- a/client/src/components/matches/MatchVideoListItem.vue
+++ b/client/src/components/matches/MatchVideoListItem.vue
@@ -33,7 +33,7 @@
         Retry
       </VBtn>
       <VBtn
-        v-else-if="!video.workerJobId && !hideUploadBtn"
+        v-else-if="!video.workerJobId && !isUploaded && !hideUploadBtn"
         variant="text"
         prepend-icon="mdi-upload"
         :disabled="matchStore.uploadInProgress"
@@ -131,6 +131,11 @@ const subtitle = computed(() => {
   }
 
   return `${uploadStatus.value} | ${postUploadStatus}${props.video.path}`;
+});
+
+const isUploaded = computed(() => {
+  return props.video.isUploaded ||
+    (props.video.workerJobId && workerStore.jobHasStatus(props.video.workerJobId, WorkerJobStatus.COMPLETED));
 });
 
 const icon = computed((): {

--- a/client/src/stores/autoRename.ts
+++ b/client/src/stores/autoRename.ts
@@ -164,6 +164,41 @@ export const useAutoRenameStore = defineStore("autoRename", () => {
     undoRenameLoading.value = false;
   }
 
+  const triggerNowError = ref("");
+  const triggerNowLoading = ref(false);
+  const triggerNowSuccess = ref(false);
+
+  async function triggerNow() {
+    triggerNowError.value = "";
+    triggerNowSuccess.value = false;
+    triggerNowLoading.value = true;
+    const response = await fetch("/api/v1/worker/debug/autoRename")
+      .catch((error) => {
+        triggerNowError.value = `Unable to trigger auto rename: ${error}`;
+        triggerNowLoading.value = false;
+        return null;
+      });
+
+    if (!response) {
+      return;
+    }
+
+    if (!response.ok) {
+      const errorResponse = await response.json();
+      triggerNowError.value = errorResponse.message || "Unable to trigger auto rename";
+    }
+
+    const data = await response.json();
+
+    if (!data.success) {
+      console.error("Failed to trigger auto rename", data);
+      triggerNowError.value = "Unable to trigger auto rename";
+    }
+
+    triggerNowLoading.value = false;
+    triggerNowSuccess.value = true;
+  }
+
   function isEditable(association: AutoRenameAssociation) {
     if (association.status === AutoRenameAssociationStatus.STRONG) {
       const editable = !association.renameCompleted;
@@ -222,6 +257,10 @@ export const useAutoRenameStore = defineStore("autoRename", () => {
     ignoreAssociationLoading,
     isEditable,
     loadingAssociations,
+    triggerNow,
+    triggerNowError,
+    triggerNowLoading,
+    triggerNowSuccess,
     undoRename,
     undoRenameError,
     undoRenameLoading,

--- a/client/src/stores/autoRename.ts
+++ b/client/src/stores/autoRename.ts
@@ -184,8 +184,7 @@ export const useAutoRenameStore = defineStore("autoRename", () => {
     }
 
     if (!response.ok) {
-      const errorResponse = await response.json();
-      triggerNowError.value = errorResponse.message || "Unable to trigger auto rename";
+      triggerNowError.value = "Unable to trigger auto rename";
     }
 
     const data = await response.json();
@@ -193,6 +192,8 @@ export const useAutoRenameStore = defineStore("autoRename", () => {
     if (!data.success) {
       console.error("Failed to trigger auto rename", data);
       triggerNowError.value = "Unable to trigger auto rename";
+      triggerNowLoading.value = false;
+      return;
     }
 
     triggerNowLoading.value = false;

--- a/client/src/stores/autoRename.ts
+++ b/client/src/stores/autoRename.ts
@@ -185,6 +185,8 @@ export const useAutoRenameStore = defineStore("autoRename", () => {
 
     if (!response.ok) {
       triggerNowError.value = "Unable to trigger auto rename";
+      triggerNowLoading.value = false;
+      return;
     }
 
     const data = await response.json();

--- a/client/src/stores/worker.ts
+++ b/client/src/stores/worker.ts
@@ -1,6 +1,6 @@
-import {socket} from "@/socket";
-import {acceptHMRUpdate, defineStore} from "pinia";
-import {computed, ref, watch} from "vue";
+import { socket } from "@/socket";
+import { acceptHMRUpdate, defineStore } from "pinia";
+import { computed, ref, watch } from "vue";
 import {
   isWorkerEvent,
   isWorkerJobCompleteEvent, isWorkerJobCreatedEvent,
@@ -38,7 +38,7 @@ export const useWorkerStore = defineStore("worker", () => {
   function jobUpdatedAtSortDirection(job1Status: WorkerJobStatus, job2Status: WorkerJobStatus): number {
     if (job1Status === job2Status) {
       // Statuses to show the oldest jobs first
-      const sortAscending = [WorkerJobStatus.PENDING, WorkerJobStatus.STARTED,  WorkerJobStatus.FAILED_RETRYABLE];
+      const sortAscending = [WorkerJobStatus.PENDING, WorkerJobStatus.STARTED, WorkerJobStatus.FAILED_RETRYABLE];
       if (sortAscending.includes(job1Status)) {
         return 1;
       }
@@ -151,7 +151,8 @@ export const useWorkerStore = defineStore("worker", () => {
     // Don't update if the job status transition would be invalid (e.g., completed -> started, failed -> started)
     if (storedJob && storedJob.status === WorkerJobStatus.COMPLETED && workerJob.status === WorkerJobStatus.STARTED) {
       console.warn(`Ignoring ${event} event because of invalid status transition: completed -> started`, {
-        storedJob, workerJob,
+        storedJob,
+        workerJob,
       });
       return;
     }
@@ -159,21 +160,24 @@ export const useWorkerStore = defineStore("worker", () => {
     console.log("Stored job.status", storedJob?.status, "workerJob.status", workerJob.status, "event", event);
     if (storedJob && storedJob.status === WorkerJobStatus.STARTED && workerJob.status === WorkerJobStatus.PENDING) {
       console.warn(`Ignoring ${event} event because of invalid status transition: started -> pending`, {
-        storedJob, workerJob,
+        storedJob,
+        workerJob,
       });
       return;
     }
 
     if (storedJob && storedJob.status === WorkerJobStatus.FAILED && workerJob.status === WorkerJobStatus.STARTED) {
       console.warn(`Ignoring ${event} event because of invalid status transition: failed -> started`, {
-        storedJob, workerJob,
+        storedJob,
+        workerJob,
       });
       return;
     }
 
     if (storedJob && storedJob.status === WorkerJobStatus.COMPLETED && workerJob.status === WorkerJobStatus.FAILED) {
       console.warn(`Ignoring ${event} event because of invalid status transition: completed -> failed`, {
-        storedJob, workerJob,
+        storedJob,
+        workerJob,
       });
       return;
     }
@@ -218,6 +222,7 @@ export const useWorkerStore = defineStore("worker", () => {
   }
 
   const jobCancellationError = ref("");
+
   async function cancelJob(jobId: string) {
     jobCancellationError.value = "";
 

--- a/server/src/routes/worker.ts
+++ b/server/src/routes/worker.ts
@@ -5,6 +5,7 @@ import { graphileWorkerUtils, prisma } from "@src/server";
 import { body, matchedData, param, validationResult } from "express-validator";
 import { JobStatus } from "@prisma/client";
 import { cancelJob } from "@src/services/WorkerService";
+import { triggerAutoRenameJob } from "@src/services/AutoRenameService";
 
 export const workerRouter = Router();
 export const workerJobsRouter = Router();
@@ -161,14 +162,8 @@ workerRouter.use(Paths.Worker.Debug.Base, workerDebugRouter);
 workerDebugRouter.get(Paths.Worker.Debug.AutoRename, triggerAutoRename);
 
 async function triggerAutoRename(req: IReq, res: IRes): Promise<IRes> {
-    const job = await graphileWorkerUtils.addJob("autoRename", {
-        _cron: {
-            ts: new Date().toISOString(),
-            backfill: false,
-        },
-        manualTrigger: true,
-    }, {
-        maxAttempts: 1,
+    return res.json({
+        success: true,
+        workerJob: await triggerAutoRenameJob(),
     });
-    return res.json({ success: true, job });
 }

--- a/server/src/tasks/autoRename.ts
+++ b/server/src/tasks/autoRename.ts
@@ -233,7 +233,7 @@ export async function autoRename(payload: unknown, {
           filePath: file,
           videoFile,
           videoLabel,
-          status: AutoRenameAssociationStatus.FAILED,
+          status: AutoRenameAssociationStatus.IGNORED,
           statusReason: "Unable to parse date from file name",
         },
         update: {},


### PR DESCRIPTION
<!-- Describe your change below, leaving the checkbox at the bottom -->

Several auto rename enhancements:
- Enabling auto rename immediately triggers it + added button to manually trigger it at any time
- Weak auto rename associations sort to the top of the review queue, ahead of failed associations
- Videos whose file names don't parse as dates are now ignored instead of failed
  - You can manually associate an ignored file to a match if needed
- Fix bug where Upload buttons show for already-uploaded match videos

TODO:
- [x] Make sure you prefix your PR title (instructions https://github.com/gafirst/match-uploader/blob/main/README.md#releases) to trigger a release after you merge this PR
- [x] `yarn run test` passes locally
- [x] Docker containers run locally
