### PR TITLE
feat: Improve table row order for Auto Rename associations

### DIFF
--- a/client/src/components/autoRename/AutoRename.vue
+++ b/client/src/components/autoRename/AutoRename.vue
@@ -102,6 +102,11 @@
           AutoRenameAssociationStatus.WEAK,
           AutoRenameAssociationStatus.FAILED,
         ]"
+        :sort-by="[
+          { key: 'status', order: 'desc' },
+          { key: 'videoTimestamp', order: 'asc' },
+          { key: 'videoLabel', order: 'asc' },
+        ]"
       />
       <h2>Recently associated</h2>
       <AutoRenameAssociations
@@ -119,6 +124,11 @@
       <AutoRenameAssociations
         :included-association-statuses="[
           AutoRenameAssociationStatus.IGNORED,
+        ]"
+        :sort-by="[
+          { key: 'videoTimestamp', order: 'desc' },
+          { key: 'videoLabel', order: 'asc' },
+          { key: 'videoFileName', order: 'asc'},
         ]"
       />
     </VCol>

--- a/client/src/components/autoRename/AutoRename.vue
+++ b/client/src/components/autoRename/AutoRename.vue
@@ -126,8 +126,6 @@
           AutoRenameAssociationStatus.IGNORED,
         ]"
         :sort-by="[
-          { key: 'videoTimestamp', order: 'desc' },
-          { key: 'videoLabel', order: 'asc' },
           { key: 'videoFileName', order: 'asc'},
         ]"
       />

--- a/client/src/components/autoRename/AutoRenameAssociations.vue
+++ b/client/src/components/autoRename/AutoRenameAssociations.vue
@@ -123,9 +123,9 @@ dayjs.extend(utc);
 const {
   includedAssociationStatuses,
   sortBy = [
-    { key: 'videoTimestamp', order: 'desc' },
-    { key: 'videoLabel', order: 'asc' },
-    { key: 'status', order: 'desc' },
+    { key: "videoTimestamp", order: "desc" },
+    { key: "videoLabel", order: "asc" },
+    { key: "status", order: "desc" },
   ],
 } = defineProps<{
   includedAssociationStatuses: AutoRenameAssociationStatus[];

--- a/client/src/components/autoRename/AutoRenameAssociations.vue
+++ b/client/src/components/autoRename/AutoRenameAssociations.vue
@@ -13,11 +13,7 @@
       { title: 'Actions', key: 'actions'}
     ]"
     multi-sort
-    :sort-by="[
-      { key: 'videoTimestamp', order: 'desc' },
-      { key: 'videoLabel', order: 'asc' },
-      { key: 'status', order: 'desc' },
-    ]"
+    :sort-by="sortBy"
   >
     <!-- eslint-disable-next-line vue/valid-v-slot -->
     <template #item.status="{ item }">
@@ -116,6 +112,7 @@ import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
 import { useWorkerStore } from "@/stores/worker";
 import { WorkerJobStatus } from "@/types/WorkerJob";
+import { SortItem } from "vuetify/lib/components/VDataTable/composables/sort";
 
 dayjs.extend(advancedFormat);
 dayjs.extend(duration);
@@ -123,8 +120,16 @@ dayjs.extend(localizedFormat);
 dayjs.extend(timezone);
 dayjs.extend(utc);
 
-defineProps<{
+const {
+  includedAssociationStatuses,
+  sortBy = [
+    { key: 'videoTimestamp', order: 'desc' },
+    { key: 'videoLabel', order: 'asc' },
+    { key: 'status', order: 'desc' },
+  ],
+} = defineProps<{
   includedAssociationStatuses: AutoRenameAssociationStatus[];
+  sortBy?: SortItem[];
 }>();
 
 const autoRenameStore = useAutoRenameStore();

--- a/client/src/components/autoRename/AutoRenameAssociations.vue
+++ b/client/src/components/autoRename/AutoRenameAssociations.vue
@@ -14,9 +14,9 @@
     ]"
     multi-sort
     :sort-by="[
-      { key: 'status', order: 'desc' },
+      { key: 'videoTimestamp', order: 'desc' },
       { key: 'videoLabel', order: 'asc' },
-      { key: 'videoTimestamp', order: 'asc' },
+      { key: 'status', order: 'desc' },
     ]"
   >
     <!-- eslint-disable-next-line vue/valid-v-slot -->


### PR DESCRIPTION
<!-- Describe your change below, leaving the checkbox at the bottom -->

Made the ordering of the tables on the Auto Rename associations page more intuitive

- [x] Test locally
- [x] Make sure you prefix your PR title ([instructions](https://github.com/gafirst/match-uploader/blob/main/README.md#releases)) to trigger a release after you merge this PR
